### PR TITLE
Add reconnecting event

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,13 @@ export * from './common';
 export type EventConnecting = 'connecting';
 
 /**
+ * WebSocket connecting as part of a retry.
+ *
+ * @category Client
+ */
+export type EventReconnecting = 'reconnecting';
+
+/**
  * WebSocket has opened.
  *
  * @category Client
@@ -91,6 +98,7 @@ export type EventError = 'error';
  */
 export type Event =
   | EventConnecting
+  | EventReconnecting
   | EventOpened
   | EventConnected
   | EventPing
@@ -101,6 +109,9 @@ export type Event =
 
 /** @category Client */
 export type EventConnectingListener = () => void;
+
+/** @category Client */
+export type EventReconnectingListener = () => void;
 
 /**
  * The first argument is actually the `WebSocket`, but to avoid
@@ -176,6 +187,8 @@ export type EventErrorListener = (error: unknown) => void;
 /** @category Client */
 export type EventListener<E extends Event> = E extends EventConnecting
   ? EventConnectingListener
+  : E extends EventReconnecting
+  ? EventReconnectingListener
   : E extends EventOpened
   ? EventOpenedListener
   : E extends EventConnected
@@ -559,6 +572,7 @@ export function createClient<
     })();
     const listeners: { [event in Event]: EventListener<event>[] } = {
       connecting: on?.connecting ? [on.connecting] : [],
+      reconnecting: on?.reconnecting ? [on.reconnecting] : [],
       opened: on?.opened ? [on.opened] : [],
       connected: on?.connected ? [on.connected] : [],
       ping: on?.ping ? [on.ping] : [],
@@ -635,6 +649,7 @@ export function createClient<
             }
 
             retries++;
+            emitter.emit('reconnecting');
           }
 
           emitter.emit('connecting');


### PR DESCRIPTION
This allows us to know whether a connection attempt is expected or unexpected.

We can better manage the user experience with this knowledge. 

An alternate approach that might work would be to provide a payload for the `connecting` event that includes `retrying` (whether this is currently a retry) and possibly even `retries` (count of retries)